### PR TITLE
Fix language issue

### DIFF
--- a/src/main/resources/assets/minecraft/lang/en_us.json
+++ b/src/main/resources/assets/minecraft/lang/en_us.json
@@ -1,3 +1,0 @@
-{
-  "block.minecraft.crafting_table": "Oak Crafting Table"
-}


### PR DESCRIPTION
This PR deletes an (accidentally created?) file which seems to overwrite all translation strings from Minecraft.

Seeing as this bug is a regression, I looked through the diff of https://github.com/xanthian/variantcraftingtables/commit/dfb5d8cf1dd2d5b33faec4ebb65427c728b21f90 and noticed that this file got (accidentally?) included:

https://github.com/xanthian/variantcraftingtables/blob/dfb5d8cf1dd2d5b33faec4ebb65427c728b21f90/src/main/resources/assets/minecraft/lang/en_us.json#L1-L3

My hypothesis is that the file overwrote *all* translation strings of the game. I just tried building the mod with that file deleted & the logs are back to normal again. It looks like this translated string is already incldued in the generated assets here:

https://github.com/xanthian/variantcraftingtables/blob/dfb5d8cf1dd2d5b33faec4ebb65427c728b21f90/src/main/generated/assets/variantcraftingtables/lang/en_us.json#L2

Looking in-game, this translation does get applied, so I'm not expecting any more regressions/bugs from this.

![image](https://github.com/xanthian/variantcraftingtables/assets/39029839/a484613d-bb65-4e00-a0a0-17e12ad5f641)

Fixes #31